### PR TITLE
Fix possible bug with forbiddenPhrase search

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -5,9 +5,8 @@ const forbiddenPhrases: string[] = ["discord.gg"];
 module.exports = {
     name: "messageCreate",
     execute(message: Message) {
-        forbiddenPhrases.forEach((phrase) => {
-            if (message.content.includes(phrase)) message.delete();
-        });
+        const foundPhrase = forbiddenPhrases.find((phrase) => message.content.includes(phrase));
+        if(foundPhrase) message.delete();
 
         if (
             message.mentions.users.size > 5 &&

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -6,7 +6,7 @@ module.exports = {
     name: "messageCreate",
     execute(message: Message) {
         const foundPhrase = forbiddenPhrases.find((phrase) => message.content.includes(phrase));
-        if(foundPhrase) message.delete();
+        if(foundPhrase) return message.delete();
 
         if (
             message.mentions.users.size > 5 &&


### PR DESCRIPTION
```js
 forbiddenPhrases.forEach((phrase) => {
            if (message.content.includes(phrase)) message.delete();
        });
```
In case there are multiple "forbiddenPhrases" found in the content, the bot would attempt to delete the same message multiple time, resulting in an error.
This is why I suggest you search for it first, then call delete once
and returning also avoids the case where there was a forbiddenPhrase and more than 5 users were mentioned 